### PR TITLE
[BUG] fix variations with crown

### DIFF
--- a/booking.py
+++ b/booking.py
@@ -166,6 +166,8 @@ def dataset_from_crownoutput(
                 if var not in quantities_per_vars.keys():
                     quantities_per_vars[var] = []
                 quantities_per_vars[var].append(quantity)
+            if "-" in qwv_name:
+                logger.warning("Found a '-' in quantity name {} - This can result in unwanted behaviour for systematic shifts".format(qwv_name))
         root_file.Close()
         return quantities_per_vars
 

--- a/variations.py
+++ b/variations.py
@@ -67,8 +67,12 @@ class ReplaceVariable(Variation):
         new_actions = deepcopy(unit.actions)
         replaced = False
         if self.variation not in unit.dataset.quantities_per_vars:
-            logger.fatal(f"Variation {self.variation} not found in ntuple for dataset {unit.dataset.name}")
-            logger.fatal(f"Available variations are: {unit.dataset.quantities_per_vars.keys()}")
+            logger.fatal(
+                f"Variation {self.variation} not found in ntuple for dataset {unit.dataset.name}"
+            )
+            logger.fatal(
+                f"Available variations are: {unit.dataset.quantities_per_vars.keys()}"
+            )
             raise NameError
         else:
             list_of_quantities = set(unit.dataset.quantities_per_vars[self.variation])
@@ -121,7 +125,9 @@ class ReplaceVariable(Variation):
             logger.warning(
                 f"[Unused Variation] For variation {self.variation} on unit {unit.dataset.name} no quantities were replaced, the shift has no effect.."
             )
-            logger.warning(f"Quantities affected by {self.variation}: {list_of_quantities} ")
+            logger.warning(
+                f"Quantities affected by {self.variation}: {list_of_quantities} "
+            )
         return Unit(unit.dataset, new_selections, new_actions, self)
 
 

--- a/variations.py
+++ b/variations.py
@@ -13,7 +13,23 @@ logger = logging.getLogger(__name__)
 
 def get_quantities_from_expression(expression):
     # first change all operators to &&
-    for operator in ["<", ">", "=", "!=", "+", "-", "*", "/", "||", ">=", "<=", "&&", "(", ")", "!"]:
+    for operator in [
+        "<",
+        ">",
+        "=",
+        "!=",
+        "+",
+        "-",
+        "*",
+        "/",
+        "||",
+        ">=",
+        "<=",
+        "&&",
+        "(",
+        ")",
+        "!",
+    ]:
         expression = expression.replace(operator, "&&")
     # then remove all brackets and spaces
     expression = expression.replace(" ", "")
@@ -51,7 +67,8 @@ class ReplaceVariable(Variation):
         new_actions = deepcopy(unit.actions)
         replaced = False
         if self.variation not in unit.dataset.quantities_per_vars:
-            logger.fatal("Variation {} not found in ntuple".format(self.variation))
+            logger.fatal(f"Variation {self.variation} not found in ntuple for dataset {unit.dataset.name}")
+            logger.fatal(f"Available variations are: {unit.dataset.quantities_per_vars.keys()}")
             raise NameError
         else:
             list_of_quantities = set(unit.dataset.quantities_per_vars[self.variation])
@@ -101,7 +118,10 @@ class ReplaceVariable(Variation):
                     replaced = True
                     logger.debug(f"Replaced act {quantity} with {act.variable}")
         if not replaced:
-            logger.warning(f"For variation {self.variation} on unit {unit} no quantities were replaced, the shift has no effect..")
+            logger.warning(
+                f"[Unused Variation] For variation {self.variation} on unit {unit.dataset.name} no quantities were replaced, the shift has no effect.."
+            )
+            logger.warning(f"Quantities affected by {self.variation}: {list_of_quantities} ")
         return Unit(unit.dataset, new_selections, new_actions, self)
 
 

--- a/variations.py
+++ b/variations.py
@@ -10,6 +10,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+def get_quantities_from_expression(expression):
+    # first change all operators to &&
+    for operator in ["<", ">", "=", "!=", "+", "-", "*", "/", "||"]:
+        expression = expression.replace(operator, "&&")
+    # then remove all brackets and spaces
+    expression = expression.replace("(", " ").replace(")", " ").replace(" ", "")
+    # then split by && and remove empty strings
+    quantities = [ q for q in expression.split("&&") if not q.replace('.','',1).isdigit() and q != ""]
+    return quantities
 
 class ReplaceVariable(Variation):
     """
@@ -27,6 +36,8 @@ class ReplaceVariable(Variation):
         Variation.__init__(self, name)
         self.variation = variation
 
+
+
     def create(self, unit):
         new_selections = deepcopy(unit.selections)
         new_actions = deepcopy(unit.actions)
@@ -38,7 +49,7 @@ class ReplaceVariable(Variation):
             for quant in list_of_quants:
                 for sel_obj in new_selections:
                     for cut in sel_obj.cuts:
-                        if quant == cut.expression:
+                        if quant in get_quantities_from_expression(cut.expression):
                             cut.expression = cut.expression.replace(
                                 quant,
                                 "{quant}__{var}".format(
@@ -49,7 +60,7 @@ class ReplaceVariable(Variation):
                                 f"Replaced expression {quant} with {cut.expression} ( quant: {quant}, var: {self.variation}"
                             )
                     for weight in sel_obj.weights:
-                        if quant == weight.expression:
+                        if quant in get_quantities_from_expression(weight.expression):
                             logger.debug(f"Initial weight: {weight.expression}")
                             weight.expression = weight.expression.replace(
                                 quant,
@@ -61,7 +72,7 @@ class ReplaceVariable(Variation):
                                 f"Replaced weight {quant} with {weight.expression} ( quant: {quant}, var: {self.variation}"
                             )
                 for act in new_actions:
-                    if quant == act.variable:
+                    if quant in get_quantities_from_expression(act.variable):
                         act.variable = act.variable.replace(
                             act.variable,
                             "{quant}__{var}".format(

--- a/variations.py
+++ b/variations.py
@@ -50,10 +50,11 @@ class ReplaceVariable(Variation):
             logger.fatal("Variation {} not found in ntuple".format(self.variation))
             raise NameError
         else:
-            list_of_quantitys = set(unit.dataset.quantities_per_vars[self.variation])
+            list_of_quantities = set(unit.dataset.quantities_per_vars[self.variation])
             for sel_obj in new_selections:
                 for cut in sel_obj.cuts:
-                    for quantity in list_of_quantitys & get_quantities_from_expression(
+                    # if any quantities used in the cut are in the list of quantities affected by the variation, replace them
+                    for quantity in list_of_quantities & get_quantities_from_expression(
                         cut.expression
                     ):
                         cut.expression = cut.expression.replace(
@@ -66,7 +67,8 @@ class ReplaceVariable(Variation):
                             f"Replaced expression {quantity} with {cut.expression} ( quantity: {quantity}, var: {self.variation})"
                         )
                 for weight in sel_obj.weights:
-                    for quantity in list_of_quantitys & get_quantities_from_expression(
+                    # if any quantities used in the weight are in the list of quantities affected by the variation, replace them
+                    for quantity in list_of_quantities & get_quantities_from_expression(
                         weight.expression
                     ):
                         logger.debug(f"Initial weight: {weight.expression}")
@@ -80,7 +82,8 @@ class ReplaceVariable(Variation):
                             f"Replaced weight {quantity} with {weight.expression} ( quantity: {quantity}, var: {self.variation})"
                         )
             for act in new_actions:
-                for quantity in list_of_quantitys & get_quantities_from_expression(
+                # if any quantities used in the action variables are in the list of quantities affected by the variation, replace them
+                for quantity in list_of_quantities & get_quantities_from_expression(
                     act.variable
                 ):
                     act.variable = act.variable.replace(


### PR DESCRIPTION
Everything we have tried so far has not been sufficient to catch every corner case; therefore, we need the hard way. 

We must disassemble every cut string and filter out the variables used in the cut string. After that, we can check for every variable if the shifted version is required. This allows us, in turn, to speed up the code a bit since we are now able to use sets instead of looping with an if statement.

I hope I have added all possible operators; if you know any additional ones, let me know!