### PR TITLE
Refactor validity check for input files.

### DIFF
--- a/booking.py
+++ b/booking.py
@@ -335,6 +335,18 @@ def dataset_from_crownoutput(
                 friends.append(Ntuple(friend_path, tdf_tree))
         if not validation_dict["files"][root_file]["is_empty"]:
             ntuples.append(Ntuple(root_file, tdf_tree, add_tagged_friends(friends)))
+    # Perform check of number of files
+    if len(validation_dict["files"].keys()) > len(root_files):
+        miss_files = set(validation_dict["files"].keys()).difference(
+            set(rfile[0] for rfile in root_files)
+        )
+        logger.fatal(
+            f"Number of files expected and in database do not agree for dataset {dataset_name}.\n"
+            f"The missing files are: {miss_files}"
+        )
+        raise ValueError(
+            f"Number of files expected and in database do not agree for dataset {dataset_name}."
+        )
     # Report on obtained validation information for dataset
     found_error = False
     for root_file, _ in root_files:

--- a/booking.py
+++ b/booking.py
@@ -121,7 +121,6 @@ def dataset_from_crownoutput(
     file_names,
     era,
     channel,
-    folder,
     files_base_directory,
     friends_base_directories=None,
     validate_samples=False,

--- a/booking.py
+++ b/booking.py
@@ -121,6 +121,7 @@ def dataset_from_crownoutput(
     file_names,
     era,
     channel,
+    folder,
     files_base_directory,
     friends_base_directories=None,
     validate_samples=False,


### PR DESCRIPTION
Accessing the files on dCache via xrootd consumes quite some time as a request is opened for each file and the list of files is quite long. The idea of the refactoring is to write a `.yaml` file for each dataset in the first run over a set of datasets. In the following runs this file can then be used to retrieve the information and the files only need to be opened when they are read. 