### PR TITLE
Gridka redirector is changed

### DIFF
--- a/booking.py
+++ b/booking.py
@@ -255,7 +255,7 @@ def dataset_from_crownoutput(
     root_files = []
     # Set up reading of file system via xrootd bindings
     if xrootd:
-        fsname = "root://cmsxrootd-kit-disk.gridka.de:1094"
+        fsname = "root://cmsdcache-kit-disk.gridka.de:1094"
         xrdclient = client.FileSystem(fsname)
         for f in file_names:
             status, listing = xrdclient.dirlist(


### PR DESCRIPTION
Changed dridka re-director from cms{xrootd} to cms{dcache} with respect to last update 